### PR TITLE
Mobile version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## PROJECTS / my recent apps
 
-#### I created this simple app to showcase some of my recent projects (MVPs) and at the same time - to practice a bit with Vue.js.
-:exclamation: Click [HERE](https://my-recent-apps.netlify.app/) to check out the deployed version :exclamation:
+#### I created this simple app to showcase some of my recent projects (MVPs) and at the same time - to practice a bit with Vue.js and responsive design.
 
+:exclamation: Click [HERE](https://my-recent-apps.netlify.app/) to check out the deployed version :exclamation:
 
 ### Demo
 
@@ -15,10 +15,13 @@
 - clone this app
 - cd into your project
 - install dependencies:
+
 ```
 npm install
 ```
+
 - start development server:
+
 ```
 npm run serve
 ```

--- a/src/App.vue
+++ b/src/App.vue
@@ -221,14 +221,13 @@ body {
   .demoImg {
     display: none;
   }
-  .project-item {
+  .project-item.project-item {
     border-radius: 12px;
-    border: 5px white solid;
+    border-right: 5px white solid;
   }
   .footers {
     margin-top: 20px;
     padding-top: 15px;
-
     border-top: 1px solid gray;
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -232,4 +232,11 @@ body {
     border-top: 1px solid gray;
   }
 }
+
+@media (max-width: 375px) {
+  .project-item {
+    max-width: 280px;
+    max-height: 280px;
+  }
+}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,8 @@
 <template>
   <div id="app">
-    <Header />
+    <Header class="headTitle" />
     <div class="grid">
-      <Info />
+      <Info class="infoSidebar" />
       <Projects v-bind:projects="projects" class="projects" />
       <div class="rightSidebarWrapper">
         <div class="rightSidebar">
@@ -21,7 +21,7 @@ import Info from "./components/Info";
 import Projects from "./components/Projects";
 import Skills from "./components/Skills";
 import Footers from "./components/Footers";
-//assets (tech-skills):
+//assets:
 import bookapp from "./components/images/bookapp.png";
 import click from "./components/images/click.png";
 import cosmos from "./components/images/cosmos.png";
@@ -199,5 +199,37 @@ body {
   color: white;
   text-align: center;
   padding-bottom: 20px;
+}
+
+@media (max-width: 500px) {
+}
+
+@media (max-width: 768px) {
+  .grid {
+    grid-template-columns: 1fr;
+    grid-template-areas: "header" "main" "footer";
+  }
+  .infoSidebar {
+    grid-area: header;
+  }
+  .projects {
+    grid-area: main;
+  }
+  .rightSidebarWrapper {
+    grid-area: footer;
+  }
+  .demoImg {
+    display: none;
+  }
+  .project-item {
+    border-radius: 12px;
+    border: 5px white solid;
+  }
+  .footers {
+    margin-top: 20px;
+    padding-top: 15px;
+
+    border-top: 1px solid gray;
+  }
 }
 </style>

--- a/src/components/Info.vue
+++ b/src/components/Info.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="card">
       <span class="card__infoicon">
-        <h4 class="fa fa-info">ABOUT</h4>
+        <h4 class="fa-info">ABOUT</h4>
       </span>
       <h1 class="card__title">About me</h1>
       <p class="card__description">
@@ -84,5 +84,28 @@
 .card:hover .card__infoicon,
 .card:focus .card__infoicon {
   opacity: 0;
+}
+
+@media (max-width: 500px) {
+}
+
+@media (max-width: 768px) {
+  .card {
+    clip-path: none;
+    transition: none;
+    border-radius: 12px;
+    background: none;
+    padding-top: 0px;
+  }
+  .card__description,
+  .card__title {
+    color: white;
+    text-align: center;
+    max-width: 350px;
+    margin: 0 auto;
+  }
+  .card__infoicon {
+    display: none;
+  }
 }
 </style>

--- a/src/components/Info.vue
+++ b/src/components/Info.vue
@@ -86,9 +86,6 @@
   opacity: 0;
 }
 
-@media (max-width: 500px) {
-}
-
 @media (max-width: 768px) {
   .card {
     clip-path: none;
@@ -106,6 +103,12 @@
   }
   .card__infoicon {
     display: none;
+  }
+}
+@media (max-width: 375px) {
+  .card__description,
+  .card__title {
+    max-width: 280px;
   }
 }
 </style>

--- a/src/components/Info.vue
+++ b/src/components/Info.vue
@@ -104,6 +104,14 @@
   .card__infoicon {
     display: none;
   }
+  .card:hover,
+  .card:focus {
+    clip-path: none;
+    border-radius: none;
+    box-shadow: none;
+    background: none;
+    cursor: auto;
+  }
 }
 @media (max-width: 375px) {
   .card__description,


### PR DESCRIPTION
I adjusted grid / created grit templates areas, to make responsive design and fix hover issue. 
I decided to hide the projects demo images and left only green boxes (project-items), to make layout clean and readable. 

<img width="485" alt="Screenshot 2020-07-23 at 16 14 51" src="https://user-images.githubusercontent.com/62424217/88297501-433d3400-cd00-11ea-9a66-21e312e5aedc.png">
